### PR TITLE
Build command

### DIFF
--- a/sooch/commands/base.py
+++ b/sooch/commands/base.py
@@ -221,5 +221,11 @@ async def build(client: discord.Client,
         )
         return result
     else:
-        return result  # TODO: cannot buy
+        result.add_field(
+            name="You cannot afford this!",
+            value=f"You need {utilities.format_balance(required_cost)} <:sooch:804702160217440276>, "
+                  f"but only have {utilities.format_balance(player.sooch)} <:sooch:804702160217440276>.",
+            inline=False
+        )
+        return result
 

--- a/sooch/commands/base.py
+++ b/sooch/commands/base.py
@@ -176,7 +176,46 @@ async def build(client: discord.Client,
         # Set the new sooch amount and build count.
         await player_svc.set_sooch(player_id, player.sooch - required_cost)
         await reg_buildings_svc.set_building_count(player_id, building.id, building_array[building.id] + amount)
-        return result  # TODO: bought
+
+        name = "New Propert"
+        property_name = building.name
+        if amount == 1:
+            name += "y"
+        else:
+            name += "ies"
+            property_name += "s"
+
+        new_count = await reg_buildings_svc.get_building_count(player_id)
+        result.add_field(
+            name=name,
+            value=f"Bought {amount} {property_name} for {utilities.format_balance(required_cost)} "
+                  f"<:sooch:804702160217440276>. Income: **{utilities.format_balance(building.income)}** "
+                  f"<:sooch:804702160217440276>/hr",
+            inline=False
+        )
+        result.add_field(
+            name="Income",
+            value=f"{utilities.format_balance(old_income)} <:sooch:804702160217440276>/hr"
+                  f"\n     ▼ ▼ ▼"
+                  f"\n{utilities.format_balance(utilities.determine_income(new_count))}"
+                  f" <:sooch:804702160217440276>/hr",
+            inline=True
+        )
+        result.add_field(
+            name="Balance",
+            value=f"{utilities.format_balance(old_balance)} <:sooch:804702160217440276>"
+                  f"\n     ▼ ▼ ▼"
+                  f"\n{utilities.format_balance(old_balance - required_cost)} <:sooch:804702160217440276>",
+            inline=True
+        )
+        result.add_field(
+            name="Cost",
+            value=f"{utilities.format_balance(required_cost)} <:sooch:804702160217440276> per {property_name}"
+                  f"\n     ▼ ▼ ▼"
+                  f"\n{utilities.format_balance(building.get_cost(new_amount, new_amount + 1, 1.0))}"
+                  f" <:sooch:804702160217440276> per {property_name}"
+        )
+        return result
     else:
         return result  # TODO: cannot buy
 

--- a/sooch/commands/base.py
+++ b/sooch/commands/base.py
@@ -158,8 +158,12 @@ async def build(client: discord.Client,
                 building = buildings.reg_buildings[int(content[1]) - 1]
             else:
                 building = buildings.reg_building_lookup[content[1]]
-        except IndexError:
-            # TODO: send error message
+        except KeyError or IndexError:
+            result.add_field(
+                name="This building doesn't exist.",
+                value=f"Yeah, {content[1]} definitely doesn't exist.",
+                inline=False
+            )
             return result
 
     amount = 1

--- a/sooch/commands/base.py
+++ b/sooch/commands/base.py
@@ -95,7 +95,8 @@ async def claim(client: discord.Client,
 async def build(client: discord.Client,
                 message: discord.Message,
                 content: list[str]) -> Optional[discord.Embed]:
-
+    """Handles the s!build command."""
+    # TODO: Plaao said they want to reduce database usage so this may require some review/rewriting.
     player_id = message.author.id
     # Get the Sooch player
     player = await player_svc.get_player(player_id)

--- a/sooch/commands/base.py
+++ b/sooch/commands/base.py
@@ -106,7 +106,9 @@ async def build(client: discord.Client,
     result = discord.Embed()
 
     # Get basic player information.
+    building_array = await reg_buildings_svc.get_building_count(player_id)
     old_balance = player.sooch
+    old_income = utilities.determine_income(building_array)
     # If there's no building specified to be built
     if not content[1:]:
         result.add_field(
@@ -164,10 +166,10 @@ async def build(client: discord.Client,
     # If an amount has been specified
     if content[2:] and content[2].isnumeric():
         amount = int(content[2])
-    # Get the required cost for building the properties
-    building_array = await reg_buildings_svc.get_building_count(player_id)
+
     building_amount = building_array[building.id]
-    required_cost = building.get_cost(building_amount, building_amount + amount, 1.0)  # TODO: variable cost reduction
+    new_amount = building_amount + amount
+    required_cost = building.get_cost(building_amount, new_amount, 1.0)  # TODO: variable cost reduction
     # If the player can afford to build the new properties, let them proceed.
     # If not, tell them they can't afford the property/ies.
     if player.sooch >= required_cost:

--- a/sooch/commands/base.py
+++ b/sooch/commands/base.py
@@ -158,7 +158,7 @@ async def build(client: discord.Client,
                 # Add 1 to it so
                 building = buildings.reg_buildings[int(content[1]) - 1]
             else:
-                building = buildings.reg_building_lookup[content[1]]
+                building = buildings.reg_building_lookup[content[1].lower()]
         except KeyError or IndexError:
             result.add_field(
                 name="This building doesn't exist.",

--- a/sooch/commands/base.py
+++ b/sooch/commands/base.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 import discord
 
-from sooch import buildings
+from sooch import buildings, utilities
 from sooch.services.players import Player, Players
 from sooch.services.reg_buildings import RegBuildings
 
@@ -72,7 +72,7 @@ async def claim(client: discord.Client,
             name="Claim Results",
             value=("Claimed {} Sooch from a total of "
                    "{} properties after 1 minute.").format(
-                       income, building_count),
+                       utilities.format_balance(income), building_count),
             inline=False
         )
     else:
@@ -80,12 +80,12 @@ async def claim(client: discord.Client,
             name="Claim Results",
             value=("Claimed {} Sooch from a total of "
                    "{} properties after {} minutes.").format(
-                       income, building_count, delta_min),
+                       utilities.format_balance(income), building_count, delta_min),
             inline=False
         )
     result.add_field(
         name="New Balance",
-        value=f"{new_sooch_balance} Sooch",
+        value=f"{utilities.format_balance(new_sooch_balance)} Sooch",
         inline=False
     )
 

--- a/sooch/commands/base.py
+++ b/sooch/commands/base.py
@@ -215,10 +215,10 @@ async def build(client: discord.Client,
         )
         result.add_field(
             name="Cost",
-            value=f"{utilities.format_balance(required_cost)} <:sooch:804702160217440276> per {property_name}"
+            value=f"{utilities.format_balance(required_cost)} <:sooch:804702160217440276> per {building.name}"
                   f"\n     ▼ ▼ ▼"
                   f"\n{utilities.format_balance(building.get_cost(new_amount, new_amount + 1, 1.0))}"
-                  f" <:sooch:804702160217440276> per {property_name}"
+                  f" <:sooch:804702160217440276> per {building.name}"
         )
         return result
     else:

--- a/sooch/message.py
+++ b/sooch/message.py
@@ -49,6 +49,13 @@ commands = [
         syntax="s!help <command>",
         handler=help.help_command
     ),
+    Command(
+        name="s!build",
+        description="Build a property which increases your income",
+        aliases=["s!b"],
+        syntax="s!build <Building> [Amount]",
+        handler=base.build
+    )
 ]
 invalid_command = Command(handler=misc.invalid)
 help.populate_help_embeds(commands)

--- a/sooch/services/reg_buildings.py
+++ b/sooch/services/reg_buildings.py
@@ -5,7 +5,7 @@ set_query: list[str] = []
 for set_building_id in range(1, 51+1):
     set_query.append(
         f"INSERT INTO `reg_buildings`(`discord_id`, `b{set_building_id}`) "
-        f"VALUES (?, ?) ON CONFLICT DO "
+        f"VALUES (?, ?) ON CONFLICT(`discord_id`) DO "
         f"UPDATE SET `b{set_building_id}` = ? WHERE `discord_id`=?"
     )
 

--- a/sooch/utilities.py
+++ b/sooch/utilities.py
@@ -1,0 +1,31 @@
+"""
+A class to store all utilities which may be reused several times within the code.
+"""
+from sooch import buildings
+
+
+def format_balance(bal: float) -> str:
+    """
+    Used to format a decimal into either standard form (when it goes over 1.0e+10)
+    Or places commas every 3 numbers.
+
+    This makes balances/costs easier to read.
+    :param bal: the decimal itself.
+    :return: the formatted decimal as a string.
+    """
+    if bal > 1.00e+10:
+        return '{:.2e}'.format(bal)
+    else:
+        return '{:,}'.format(bal)
+
+
+def determine_income(count: tuple[int]) -> float:
+    """
+    Used to determine a user's income from their building counts.
+    :param count: The tuple of building counts.
+    :return: The income in sooch/hour.
+    """
+    income = 0
+    for building_id, building in enumerate(buildings.reg_buildings):
+        income += count[building_id] * building.income
+    return income


### PR DESCRIPTION
This PR implements the build command as a base command, allowing users to build properties in order to gain more sooch in a given time frame. There are some other fixes applied in this PR, such as overflowing numbers that never got shortened (causing an error as the number would exceed Discord's maximum field length) and an SQL syntax error I was getting. Embed album - https://imgur.com/a/YFM9Rj5

Currently, the majority of TODOs in this apply to the s!claim as well, such as removing heavy reliance on the database and taking into account claim time acceleration. Another TODO in this is to note cost reduction but may be for the future with claim time acceleration.

Main differences from legacy include:
- Different s!build list layout. 
- Different s!build payment layout, intended on being a bit more compact and remove whitespace.

Known issues:
- Only uses local emotes from my server, not any official Sooch emote IDs.
- ~~Should s!b FARM return an error or let the user build a farm? s!b farm works on itself but otherwise adding capital letters doesn't seem to work.~~ patched in [5b63cdc](https://github.com/plaaosert/sooch-rewrite/pull/17/commits/5b63cdc8faa9babaf20453f674ed91c50a34c129)